### PR TITLE
General JS refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const canvasCtx = canvas.getContext("2d");
 function downloadJSON(obj, name) {
   const dataStr =
     "data:text/jsoncharset=utf-8," + encodeURIComponent(JSON.stringify(obj));
-  
+
   downloadAnchor.setAttribute("href", dataStr);
   downloadAnchor.setAttribute("download", name);
   downloadAnchor.click();
@@ -66,7 +66,7 @@ function process() {
   }
 
   scaledLabel.innerHTML = `Scaled to ${pageW} by ${pageH} pages.<br>
-  ${pageH * pageW} pieces of paper.<br> ${pageH * pageW * 5000} ink.<br>`
+  ${pageH * pageW} pieces of paper.<br> ${pageH * pageW * 5000} ink.<br>`;
 
   size = [PAGE_WIDTH * pageW, PAGE_HEIGHT * pageH];
   canvas.width = size[0];
@@ -103,9 +103,10 @@ function process() {
         new Uint8ClampedArray(quantizedImage),
         canvas.width,
         canvas.height
-      ), 0, 0
+      ),
+      0,
+      0
     );
-
   } else {
     paletteImage = [];
     palettes = [];
@@ -160,7 +161,6 @@ function process() {
   }
 
   if (transparency.checked) {
-
     // Transfer transparency
     const imageData = canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
 
@@ -182,7 +182,7 @@ function process() {
   }
 
   processedImageOutput.src = canvas.toDataURL("image/png"); // show the preview
-};
+}
 
 const monitorChanges = [
   serpentineDither,
@@ -260,7 +260,7 @@ function getPixels(px, py) {
       pixels.push(paletteIndex);
     }
   }
-  
+
   return pixels;
 }
 
@@ -295,11 +295,9 @@ saveButton.onclick = () => {
 
   for (var y = 1; y <= pageH; y++) {
     for (var x = 1; x <= pageW; x++) {
-
       let pageInfo = "";
       if (appendPageInfo.checked) {
-        pageInfo =
-          ` : page (${x}, ${y}) of (${pageW}x${pageH})`;
+        pageInfo = ` : page (${x}, ${y}) of (${pageW}x${pageH})`;
       }
 
       pages.push({
@@ -326,13 +324,12 @@ saveButton.onclick = () => {
         fn + ".2dja"
       );
     }
-
   } else if (outputFormat.value == "zip") {
     const zip = new JSZip();
 
     pages.forEach((page) => {
-      zip.file(page.label + ".2dj", JSON.stringify(page))
-    })
+      zip.file(page.label + ".2dj", JSON.stringify(page));
+    });
 
     zip.generateAsync({ type: "base64" }).then(function (base64) {
       const dataStr = "data:application/zip;base64," + base64;

--- a/index.js
+++ b/index.js
@@ -1,273 +1,344 @@
 function rgbArrToRgbTuples(arr) {
-	var newArr = []
-	for (fullrgb of arr) {
-		newArr.push([
-			fullrgb >> 16,
-			(fullrgb >> 8) & 0xFF,
-			fullrgb & 0xFF,
-		])
-	}
-	return newArr
+  return arr.map((fullrgb) => [
+    fullrgb >> 16,
+    (fullrgb >> 8) & 0xff,
+    fullrgb & 0xff,
+  ]);
 }
 
-const canvas = document.getElementById("canvas")
-const canvasCtx = canvas.getContext("2d")
-const processButton = document.getElementById("process")
-const saveButton = document.getElementById("save")
-const serpentineDither = document.getElementById("serpentineDither")
-const perPageDither = document.getElementById("perPageDither")
-const ditherType = document.getElementById("ditherType")
-const image = document.getElementById("image")
-const manyPages = document.getElementById("manypages")
-const specPages = document.getElementById("specpages")
-const outputFormat = document.getElementById("outputFormat")
-const pagesX = document.getElementById("pagesx")
-const pagesY = document.getElementById("pagesy")
-const transparency = document.getElementById("transparency")
-const pageCanvas = document.getElementById("pageCanvas")
-const pageCtx = pageCanvas.getContext("2d")
-const automaticLabel = document.getElementById("automaticLabel")
-const manualLabel = document.getElementById("manualLabel")
-const appendPageInfo = document.getElementById("appendPageInfo")
-const manualLabelInput = document.getElementById("manualLabelInput")
-const imageInput = document.getElementById("imageInput")
-const autoProcess = document.getElementById("autoProcess")
+const canvas = document.querySelector("#canvas");
+const processButton = document.querySelector("#process");
+const saveButton = document.querySelector("#save");
+const serpentineDither = document.querySelector("#serpentineDither");
+const perPageDither = document.querySelector("#perPageDither");
+const ditherType = document.querySelector("#ditherType");
+const image = document.querySelector("#image");
+const manyPages = document.querySelector("#manypages");
+const specPages = document.querySelector("#specpages");
+const outputFormat = document.querySelector("#outputFormat");
+const pagesX = document.querySelector("#pagesx");
+const pagesY = document.querySelector("#pagesy");
+const transparency = document.querySelector("#transparency");
+const pageCanvas = document.querySelector("#pageCanvas");
+const automaticLabel = document.querySelector("#automaticLabel");
+const manualLabel = document.querySelector("#manualLabel");
+const appendPageInfo = document.querySelector("#appendPageInfo");
+const manualLabelInput = document.querySelector("#manualLabelInput");
+const imageInput = document.querySelector("#imageInput");
+const autoProcess = document.querySelector("#autoProcess");
+const downloadAnchor = document.querySelector("#downloadAnchorElem");
+const processedImageOutput = document.querySelector("#processedImage");
+const scaledLabel = document.querySelector("#scaledLabel");
+const pageCtx = pageCanvas.getContext("2d");
+const canvasCtx = canvas.getContext("2d");
 
 function downloadJSON(obj, name) {
-	var dataStr = "data:text/jsoncharset=utf-8," + encodeURIComponent(JSON.stringify(obj))
-	var dlAnchorElem = document.getElementById('downloadAnchorElem')
-	dlAnchorElem.setAttribute("href", dataStr)
-	dlAnchorElem.setAttribute("download", name)
-	dlAnchorElem.click()
+  const dataStr =
+    "data:text/jsoncharset=utf-8," + encodeURIComponent(JSON.stringify(obj));
+  
+  downloadAnchor.setAttribute("href", dataStr);
+  downloadAnchor.setAttribute("download", name);
+  downloadAnchor.click();
 } // https://stackoverflow.com/questions/19721439/download-json-object-as-a-file-from-browser
 
-const PAGE_WIDTH = 128
-const PAGE_HEIGHT = 128
+const PAGE_WIDTH = 128;
+const PAGE_HEIGHT = 128;
 
-var size = [PAGE_WIDTH, PAGE_HEIGHT]
-var pageW = 1
-var pageH = 1
-var palette = []
-var palettes = []
-var paletteImage = []
+let size = [PAGE_WIDTH, PAGE_HEIGHT];
+let pageW = 1;
+let pageH = 1;
+let palette = [];
+let palettes = [];
+let paletteImage = [];
 
-const processedImageOutput = document.getElementById("processedImage")
+function process() {
+  canvasCtx.fillStyle = "black";
+  let quantizer = new RgbQuant({ colors: 63 });
+  pageW = 1;
+  pageH = 1;
 
-const process = () => {
-	canvasCtx.fillStyle = "black"
-	var quantizer = new RgbQuant({ colors: 63 })
-	pageW = 1
-	pageH = 1
-	if (specPages.checked) {
-		pageW = pagesX.value
-		pageH = pagesY.value
-	} else if (manyPages.checked) {
-		pageW = Math.max(Math.floor(image.width / PAGE_WIDTH), 1)
-		pageH = Math.max(Math.floor(image.height / PAGE_HEIGHT), 1)
-	}
-	document.getElementById("scaledLabel").innerHTML = "Scaled to " + pageW + " by " + pageH + " pages." + "<br>"
-		+ pageH * pageW + " pieces of paper.<br>"
-		+ pageH * pageW * 5000 + " ink.<br>"
-	var closestWidth = PAGE_WIDTH * pageW
-	var closestHeight = PAGE_HEIGHT * pageH
-	size = [closestWidth, closestHeight]
-	canvas.width = size[0]
-	canvas.height = size[1]
-	// clear the canvas
-	canvasCtx.clearRect(0, 0, canvas.width, canvas.height)
-	// draw the image
-	canvasCtx.drawImage(image, 0, 0, canvas.width, canvas.height)
-	// generate the palette
-	quantizer.sample(canvas)
-	if (!perPageDither.checked) {
-		// quantize the image
-		var quantizedImage = quantizer.reduce(canvas, null, ditherType.value, serpentineDither.checked)
-		// Get palette image
-		paletteImage = quantizer.reduce(canvas, 2, ditherType.value, serpentineDither.checked)
-		palette = quantizer.palette(true, true)
-		// draw it on the canvas
-		canvasCtx.putImageData(new ImageData(new Uint8ClampedArray(quantizedImage), canvas.width, canvas.height), 0, 0)
-	} else {
-		paletteImage = []
-		palettes = []
-		for (py = 0; py < pageH; py++) {
-			palettes[py] = palettes[py] || []
-			for (px = 0; px < pageW; px++) {
-                pageCtx.clearRect(0, 0, PAGE_WIDTH, PAGE_HEIGHT)
-				pageCtx.drawImage(canvas, px*PAGE_WIDTH, py*PAGE_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, 0, 0, PAGE_WIDTH, PAGE_HEIGHT)
-				quantizer = new RgbQuant({ colors: 63 })
-				quantizer.sample(pageCanvas)
-				var quantImage = quantizer.reduce(pageCanvas, null, ditherType.value, serpentineDither.checked)
-				var palImage = quantizer.reduce(pageCanvas, 2, ditherType.value, serpentineDither.checked)
-				mergeIntoPaletteImage(px, py, palImage)
-				palettes[py][px] = quantizer.palette(true, true)
-				canvasCtx.putImageData(new ImageData(new Uint8ClampedArray(quantImage), PAGE_WIDTH, PAGE_HEIGHT), px*PAGE_WIDTH, py*PAGE_HEIGHT)
-			}
-		}
-	}
+  if (specPages.checked) {
+    pageW = pagesX.value;
+    pageH = pagesY.value;
+  } else if (manyPages.checked) {
+    pageW = Math.max(Math.floor(image.width / PAGE_WIDTH), 1);
+    pageH = Math.max(Math.floor(image.height / PAGE_HEIGHT), 1);
+  }
 
-	if (transparency.checked) {
-		// Transfer transparency
-		var imageData = canvasCtx.getImageData(0,0,canvas.width,canvas.height)
-		for (var y = 0; y < imageData.height; y++) {
-			var rowStart = y*imageData.width
-			for (var x = 0; x < imageData.width; x++) {
-				var index = (x+rowStart)*4 + 3
-				if (imageData[index] < 125) { // check for transparent pixels from the source image
-					paletteImage[x+rowStart] = -1
-				} 
-				if (paletteImage[x+rowStart] == null) {
-					paletteImage[x+rowStart] = -1
-				}
-			}
-		}
-	}
+  scaledLabel.innerHTML = `Scaled to ${pageW} by ${pageH} pages.<br>
+  ${pageH * pageW} pieces of paper.<br> ${pageH * pageW * 5000} ink.<br>`
 
-	processedImageOutput.src = canvas.toDataURL("image/png") // show the preview
-}
+  size = [PAGE_WIDTH * pageW, PAGE_HEIGHT * pageH];
+  canvas.width = size[0];
+  canvas.height = size[1];
+
+  // clear the canvas
+  canvasCtx.clearRect(0, 0, canvas.width, canvas.height);
+  // draw the image
+  canvasCtx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  // generate the palette
+  quantizer.sample(canvas);
+
+  if (!perPageDither.checked) {
+    // quantize the image
+    const quantizedImage = quantizer.reduce(
+      canvas,
+      null,
+      ditherType.value,
+      serpentineDither.checked
+    );
+
+    // Get palette image
+    paletteImage = quantizer.reduce(
+      canvas,
+      2,
+      ditherType.value,
+      serpentineDither.checked
+    );
+    palette = quantizer.palette(true, true);
+
+    // draw it on the canvas
+    canvasCtx.putImageData(
+      new ImageData(
+        new Uint8ClampedArray(quantizedImage),
+        canvas.width,
+        canvas.height
+      ), 0, 0
+    );
+
+  } else {
+    paletteImage = [];
+    palettes = [];
+
+    for (let py = 0; py < pageH; py++) {
+      palettes[py] = palettes[py] || [];
+
+      for (let px = 0; px < pageW; px++) {
+        pageCtx.clearRect(0, 0, PAGE_WIDTH, PAGE_HEIGHT);
+        pageCtx.drawImage(
+          canvas,
+          px * PAGE_WIDTH,
+          py * PAGE_WIDTH,
+          PAGE_WIDTH,
+          PAGE_HEIGHT,
+          0,
+          0,
+          PAGE_WIDTH,
+          PAGE_HEIGHT
+        );
+
+        quantizer = new RgbQuant({ colors: 63 });
+        quantizer.sample(pageCanvas);
+
+        const quantImage = quantizer.reduce(
+          pageCanvas,
+          null,
+          ditherType.value,
+          serpentineDither.checked
+        );
+        const palImage = quantizer.reduce(
+          pageCanvas,
+          2,
+          ditherType.value,
+          serpentineDither.checked
+        );
+
+        mergeIntoPaletteImage(px, py, palImage);
+        palettes[py][px] = quantizer.palette(true, true);
+
+        canvasCtx.putImageData(
+          new ImageData(
+            new Uint8ClampedArray(quantImage),
+            PAGE_WIDTH,
+            PAGE_HEIGHT
+          ),
+          px * PAGE_WIDTH,
+          py * PAGE_HEIGHT
+        );
+      }
+    }
+  }
+
+  if (transparency.checked) {
+
+    // Transfer transparency
+    const imageData = canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
+
+    for (let y = 0; y < imageData.height; y++) {
+      const rowStart = y * imageData.width;
+
+      for (let x = 0; x < imageData.width; x++) {
+        const index = (x + rowStart) * 4 + 3;
+        if (imageData[index] < 125) {
+          // check for transparent pixels from the source image
+          paletteImage[x + rowStart] = -1;
+        }
+
+        if (paletteImage[x + rowStart] === null) {
+          paletteImage[x + rowStart] = -1;
+        }
+      }
+    }
+  }
+
+  processedImageOutput.src = canvas.toDataURL("image/png"); // show the preview
+};
 
 const monitorChanges = [
-    serpentineDither,
-    perPageDither,
-    ditherType,
-    manyPages,
-    specPages,
-    pagesX,
-    pagesY,
-    transparency,
+  serpentineDither,
+  perPageDither,
+  ditherType,
+  manyPages,
+  specPages,
+  pagesX,
+  pagesY,
+  transparency,
 ];
 
 monitorChanges.forEach((element) => {
-	element.addEventListener("input", () => {
-		if (autoProcess.checked) {
-        process();
-        }	
-	})
-})
+  element.addEventListener("input", () => {
+    if (autoProcess.checked) {
+      process();
+    }
+  });
+});
 
-imageInput.onchange = function (event) {
-    var selectedFile = event.target.files[0];
-    var reader = new FileReader();
+imageInput.onchange = (event) => {
+  const selectedFile = event.target.files[0];
+  const reader = new FileReader();
 
-    canvas.title = selectedFile.name;
+  canvas.title = selectedFile.name;
 
-	reader.onload = function (event) {
-		image.src = event.target.result;
-	};
+  reader.onload = (event) => {
+    image.src = event.target.result;
+  };
 
-	reader.readAsDataURL(selectedFile);
+  reader.readAsDataURL(selectedFile);
 
-	// for some reason, image inputting won't cause a change unless there's a timeout here
-	setTimeout(() => {
-		if (autoProcess.checked) {
-			process();
-		}
-	}, 100)
+  // for some reason, image inputting won't cause a change unless there's a timeout here
+  setTimeout(() => {
+    if (autoProcess.checked) {
+      process();
+    }
+  }, 100);
 };
 
-function getPaletteIndex(x,y) {
-	return x + (y * size[1])
+function getPaletteIndex(x, y) {
+  return x + y * size[1];
 }
 
-function mergeIntoPaletteImage(px,py,image) {
-	var pageX = px * PAGE_WIDTH
-	var pageY = py * PAGE_HEIGHT
-	for (y = 0; y < PAGE_HEIGHT; y++) {
-		for (x = 0; x < PAGE_WIDTH; x++) {
-			var toIndex = getPaletteIndex(pageX+x, pageY + y)
-			var fromIndex = x+(y*PAGE_WIDTH)
-			paletteImage[toIndex] = image[fromIndex]
-		}
-	}
+function mergeIntoPaletteImage(px, py, image) {
+  var pageX = px * PAGE_WIDTH;
+  var pageY = py * PAGE_HEIGHT;
+  for (y = 0; y < PAGE_HEIGHT; y++) {
+    for (x = 0; x < PAGE_WIDTH; x++) {
+      var toIndex = getPaletteIndex(pageX + x, pageY + y);
+      var fromIndex = x + y * PAGE_WIDTH;
+      paletteImage[toIndex] = image[fromIndex];
+    }
+  }
 }
 
 processButton.onclick = process;
 
 function getPageIndex(px, py, x, y) {
-	return PAGE_WIDTH * pageW * (y + ((py - 1) * PAGE_HEIGHT) - 1) + (px - 1) * PAGE_WIDTH + x - 1
+  return (
+    PAGE_WIDTH * pageW * (y + (py - 1) * PAGE_HEIGHT - 1) +
+    (px - 1) * PAGE_WIDTH +
+    x -
+    1
+  );
 }
 
 function getPixels(px, py) {
-	var pixels = []
-	for (y = 1; y <= PAGE_HEIGHT; y++) {
-		for (x = 1; x <= PAGE_WIDTH; x++) {
-			var onPageIndex = getPageIndex(px, py, x, y)
-			var paletteIndex = paletteImage[onPageIndex] + 1
-			pixels.push(paletteIndex)
-		}
-	}
-	return pixels
+  const pixels = [];
+
+  for (y = 1; y <= PAGE_HEIGHT; y++) {
+    for (x = 1; x <= PAGE_WIDTH; x++) {
+      const onPageIndex = getPageIndex(px, py, x, y);
+      const paletteIndex = paletteImage[onPageIndex] + 1;
+      pixels.push(paletteIndex);
+    }
+  }
+  
+  return pixels;
 }
 
-function getPalette(px,py) {
-	var palToUse = palette
-	if (perPageDither.checked) {
-		palToUse = palettes[py-1][px-1]
-	}
-	var pal = []
-	for (col of palToUse) {
-		var color = (col[0] << 16) + (col[1] << 8) + col[2]
-		pal.push(color)
-	}
-	return pal
+function getPalette(px, py) {
+  let palToUse = palette;
+
+  if (perPageDither.checked) {
+    palToUse = palettes[py - 1][px - 1];
+  }
+
+  return palToUse.map((col) => (col[0] << 16) + (col[1] << 8) + col[2]);
 }
 
-const MAX_LABEL_SIZE = 48
+const MAX_LABEL_SIZE = 48;
 
 function lengthLimit(name, info) {
-	if (name.length + info.length > MAX_LABEL_SIZE) {
-		return name.substring(0, MAX_LABEL_SIZE - info.length) + info
-	}
-	return name + info
+  if (name.length + info.length > MAX_LABEL_SIZE) {
+    return name.substring(0, MAX_LABEL_SIZE - info.length) + info;
+  }
+
+  return name + info;
 }
 
-saveButton.onclick = function (event) {
-	var fn = canvas.title.replace(/\.[^/.]+$/, "")
-	var pages = []
-	var label = fn
-	if (manualLabel.checked) {
-		label = manualLabelInput.value
-	}
-	for (var y = 1; y <= pageH; y++) {
-		for (var x = 1; x <= pageW; x++) {
-			var pageInfo = ""
-			if (appendPageInfo.checked) {
-				pageInfo = ' : page (' + x + ',' + y + ') of (' + pageW + 'x' + pageH + ')'
-			}
-			pages.push({
-				label: lengthLimit(label, pageInfo),
-				palette: getPalette(x,y),
-				pixels: getPixels(x, y),
-				width: PAGE_WIDTH,
-				height: PAGE_HEIGHT
-			})
-		}
-	}
-	if (outputFormat.value == "2dj") {
-		if (pages.length === 1) {
-            downloadJSON(pages[0], fn + ".2dj");
-        } else {
-            downloadJSON(
-                    {
-                        pages: pages,
-                        width: pageW, 
-                        height: pageH,
-                        title: fn,
-                    },
-                fn + ".2dja"
-            );
-        }
-	} else if (outputFormat.value == "zip") {
-		var zip = new JSZip()
-		for (var i = 0; i < pages.length; i++) {
-			zip.file(pages[i].label + ".2dj", JSON.stringify(pages[i]))
-		}
-		zip.generateAsync({ type: "base64" }).then(function (base64) {
-			var dataStr = "data:application/zip;base64," + base64
-			var dlAnchorElem = document.getElementById('downloadAnchorElem')
-			dlAnchorElem.setAttribute("href", dataStr)
-			dlAnchorElem.setAttribute("download", fn + ".2dj.zip")
-			dlAnchorElem.click()
-		});
-	}
-}
+saveButton.onclick = () => {
+  const fn = canvas.title.replace(/\.[^/.]+$/, "");
+  const pages = [];
+  let label = fn;
+
+  if (manualLabel.checked) {
+    label = manualLabelInput.value;
+  }
+
+  for (var y = 1; y <= pageH; y++) {
+    for (var x = 1; x <= pageW; x++) {
+
+      let pageInfo = "";
+      if (appendPageInfo.checked) {
+        pageInfo =
+          ` : page (${x}, ${y}) of (${pageW}x${pageH})`;
+      }
+
+      pages.push({
+        label: lengthLimit(label, pageInfo),
+        palette: getPalette(x, y),
+        pixels: getPixels(x, y),
+        width: PAGE_WIDTH,
+        height: PAGE_HEIGHT,
+      });
+    }
+  }
+
+  if (outputFormat.value === "2dj") {
+    if (pages.length === 1) {
+      downloadJSON(pages[0], fn + ".2dj");
+    } else {
+      downloadJSON(
+        {
+          pages: pages,
+          width: pageW,
+          height: pageH,
+          title: fn,
+        },
+        fn + ".2dja"
+      );
+    }
+
+  } else if (outputFormat.value == "zip") {
+    const zip = new JSZip();
+
+    pages.forEach((page) => {
+      zip.file(page.label + ".2dj", JSON.stringify(page))
+    })
+
+    zip.generateAsync({ type: "base64" }).then(function (base64) {
+      const dataStr = "data:application/zip;base64," + base64;
+      downloadAnchor.setAttribute("href", dataStr);
+      downloadAnchor.setAttribute("download", fn + ".2dj.zip");
+      downloadAnchor.click();
+    });
+  }
+};


### PR DESCRIPTION
I've done some refactoring in the Javascript part of 2dj-site. Some changes have been included below.

### Changes

#### `var` -> `const` / `let`

I've changed the deperacted `var` variables into `const`s or `let`s. In general `const` should be used for constants, who don't change, while `let` should be used for variables that do change. Note that if you initialize a variable with an array, you can still modify the values of the array, but you cannot make the variable something else.

#### Improved `rgbArrToRgbTuples`

The `rgbArrToRgbTuples` was a bit more complicated than it needed to. I have cleared this up to use ES6 syntax with the `array.map` function. `array.map` loops over each value of `array`, and passes this onto a function. The value in the array is then set to the return of the function.

#### Editorconfig

I've added an .editorconfig file to the repository. Editor configs can be used to set what type of indentation a project should have. I've set the editorconfig to use LF (linux) endings, and use 2 spaces for indentation. I have applied this formatting to the Javascript file, along with running over with Prettier.
